### PR TITLE
DomainBlockContentBlock constructor was updated.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,17 @@
+{
+  "name": "domain_block_content/domain_block_content",
+  "description": "Provide contact block cloning ability.",
+  "type": "drupal-module",
+  "homepage": "https://github.com/skilld-labs/domain_block_content",
+  "authors": [
+    {
+      "name": "See all contributors",
+      "homepage": "https://github.com/skilld-labs/domain_block_content/graphs/contributors"
+    }
+  ],
+  "support": {
+    "issues": "https://github.com/skilld-labs/domain_block_content/issues",
+    "source": "git@github.com:skilld-labs/domain_block_content.git"
+  },
+  "license": "GPL-2.0+"
+}

--- a/domain_block_content.info.yml
+++ b/domain_block_content.info.yml
@@ -4,5 +4,6 @@ package: Domain
 type: module
 core: 8.x
 dependencies:
-  - domain_entity
-  - entity_clone
+  - domain_entity:domain_entity
+  - entity_clone:entity_clone
+  - drupal:block_content (>= 8.4.5)

--- a/src/DomainBlockContentBlock.php
+++ b/src/DomainBlockContentBlock.php
@@ -3,9 +3,11 @@
 namespace Drupal\domain_block_content;
 
 use Drupal\block_content\BlockContentInterface;
+use Drupal\block_content\BlockContentUuidLookup;
 use Drupal\block_content\Plugin\Block\BlockContentBlock;
 use Drupal\Core\Block\BlockManagerInterface;
-use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\Core\Entity\EntityDisplayRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Routing\UrlGeneratorInterface;
 use Drupal\Core\Session\AccountInterface;
@@ -41,17 +43,21 @@ class DomainBlockContentBlock extends BlockContentBlock {
    *   The plugin implementation definition.
    * @param \Drupal\Core\Block\BlockManagerInterface $block_manager
    *   The Plugin Block Manager.
-   * @param \Drupal\Core\Entity\EntityManagerInterface $entity_manager
-   *   The entity manager service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
    * @param \Drupal\Core\Session\AccountInterface $account
    *   The account for which view access should be checked.
    * @param \Drupal\Core\Routing\UrlGeneratorInterface $url_generator
    *   The URL generator.
+   * @param \Drupal\block_content\BlockContentUuidLookup $uuid_lookup
+   *   The block content UUID lookup service.
+   * @param \Drupal\Core\Entity\EntityDisplayRepositoryInterface $entity_display_repository
+   *   The entity display repository.
    * @param \Drupal\domain_block_content\DomainBlockContentHandler $domain_block_content_handler
    *   The Domain Block content handler.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, BlockManagerInterface $block_manager, EntityManagerInterface $entity_manager, AccountInterface $account, UrlGeneratorInterface $url_generator, DomainBlockContentHandler $domain_block_content_handler) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $block_manager, $entity_manager, $account, $url_generator);
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, BlockManagerInterface $block_manager, EntityTypeManagerInterface $entity_type_manager, AccountInterface $account, UrlGeneratorInterface $url_generator, BlockContentUuidLookup $uuid_lookup, EntityDisplayRepositoryInterface $entity_display_repository, DomainBlockContentHandler $domain_block_content_handler) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $block_manager, $entity_type_manager, $account, $url_generator, $uuid_lookup, $entity_display_repository);
     $this->domainBlockContentHandler = $domain_block_content_handler;
   }
 
@@ -64,9 +70,11 @@ class DomainBlockContentBlock extends BlockContentBlock {
       $plugin_id,
       $plugin_definition,
       $container->get('plugin.manager.block'),
-      $container->get('entity.manager'),
+      $container->get('entity_type.manager'),
       $container->get('current_user'),
       $container->get('url_generator'),
+      $container->get('block_content.uuid_lookup'),
+      $container->get('entity_display.repository'),
       $container->get('domain_block_content.handler')
     );
   }


### PR DESCRIPTION
`BlockContentBlock` class `__construct()` method params was updated:

- 1 param was replaced (`$entity_manager` replaced with `$entity_type_manager`)
- 2 extra params was added (`$uuid_lookup` and `$entity_display_repository`) 

Without this change we have an error: `Too few arguments to function Drupal\block_content\Plugin\Block\BlockContentBlock::__construct(), 7 passed in /var/www/html/modules/domain_block_content/src/DomainBlockContentBlock.php on line 54 and exactly 9 expected.`